### PR TITLE
Fix aws_backup_selection name issue with / in dynamodb arns. one aws_backup_selection per resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ resource "aws_backup_selection" "resources" {
   name         = replace("${element(split(":", var.selection_resources[count.index]), 2)}-${element(split(":", var.selection_resources[count.index]), length(var.selection_resources[count.index]))}-${count.index}", "/", "-")
   iam_role_arn = aws_iam_role.backup_role[0].arn
   plan_id      = aws_backup_plan.backup_plan[0].id
-  resources    = var.selection_resources
+  resources    = [var.selection_resources[count.index]]
 }
 
 # AWS Backup vault notification

--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,7 @@ resource "aws_backup_selection" "tag" {
 # AWS Backup selection - resources arn
 resource "aws_backup_selection" "resources" {
   count        = var.enabled ? length(var.selection_resources) > 0 && var.account_type == local.account_type.workload ? length(var.selection_resources) : 0 : 0
-  name         = replace("${element(split(":", var.selection_resources[count.index]), 2)}-${element(split(":", var.selection_resources[count.index]), length(var.selection_resources[count.index]))}-${count.index}", "/", "-")
+  name         = replace("${element(split(":", var.selection_resources[count.index]), 2)}-${element(split(":", var.selection_resources[count.index]), length(split(":",var.selection_resources[count.index]))-1)}-${count.index}", "/", "-")
   iam_role_arn = aws_iam_role.backup_role[0].arn
   plan_id      = aws_backup_plan.backup_plan[0].id
   resources    = [var.selection_resources[count.index]]

--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,7 @@ resource "aws_backup_selection" "tag" {
 # AWS Backup selection - resources arn
 resource "aws_backup_selection" "resources" {
   count        = var.enabled ? length(var.selection_resources) > 0 && var.account_type == local.account_type.workload ? length(var.selection_resources) : 0 : 0
-  name         = "${element(split(":", var.selection_resources[count.index]), 2)}-${element(split(":", var.selection_resources[count.index]), length(var.selection_resources[count.index]))}-${count.index}"
+  name         = replace("${element(split(":", var.selection_resources[count.index]), 2)}-${element(split(":", var.selection_resources[count.index]), length(var.selection_resources[count.index]))}-${count.index}", "/", "-")
   iam_role_arn = aws_iam_role.backup_role[0].arn
   plan_id      = aws_backup_plan.backup_plan[0].id
   resources    = var.selection_resources


### PR DESCRIPTION
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Update aws_backup_selection name so that any / in arns are replaced with -. / are not an accpeted character for aws_backup_selection name.

If multiple resources are present it would create a aws_backup_selection for each applying all resources to each. The name would also break when more than one was being made

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...